### PR TITLE
Docker Image workflow - Option 1

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,60 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: "Publish Docker Image"
+
+env:
+  SLUG_DOCKERHUB: ${{ secrets.DOCKER_USERNAME }}/ghs-server
+  SLUG_GHCR: ghcr.io/${{ github.repository_owner }}/ghs-server
+
+jobs:
+  build-and-publish-docker-image:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      -
+        name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.SLUG_DOCKERHUB }}
+            ${{ env.SLUG_GHCR }}
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }} # automatic: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Inspect image
+        if: github.event_name != 'pull_request'
+        run: |
+          docker pull ${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}
+          docker image inspect ${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}
+          docker pull ${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}
+          docker image inspect ${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
### Option 1

- Option 1 is a **self-contained workflow** which runs independent of the existing `deploy` and `publish` workflows
- Option 1 is an **alternative** solution to Option 2, which attempts to close #3

#### Assumptions
- Official releases of the app are always in the format "v*". Both options act only on pushes of a `v*` tag
- No manipulation of Docker image name. Both options use the repository name (_ghs-server_)
- No manipulation of Docker tags. Both options will create two image `tags`. A copy of the `:v*` tag and, by default `:latest`

#### Prerequisites

- a Docker Hub account must be created
- the credentials to this account should be supplied to GitHub as secrets: `DOCKER_USERNAME` and `DOCKER_PASSWORD`