### PR TITLE
Docker/publish workflow fix for uppercase repository

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -60,5 +60,8 @@ jobs:
         run: |
           docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
-          docker pull "ghcr.io/lurkars/ghs-server:v0.30.2"
-          docker image inspect "ghcr.io/Lurkars/ghs-server:v0.30.2"
+        -
+        name: Test for GHCR
+        run: |
+          docker pull "ghcr.io/Lurkars/ghs-server:v0.30.2"
+          docker image inspect "ghcr.io/lurkars/ghs-server:v0.30.2"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,6 +8,7 @@ on:
 env:
   SLUG_DOCKERHUB: ${{ secrets.DOCKER_USERNAME }}/ghs-server
   SLUG_GHCR: ghcr.io/${{ github.repository_owner }}/ghs-server
+  SLUG_TEST: ghcr.io/Lurkars/ghs-server:v0.30.2
 
 jobs:
   build-and-publish-docker-image:
@@ -33,6 +34,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
+        id: image_lower
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ env.SLUG_TEST }}
       -
         name: Login to GHCR
         uses: docker/login-action@v2
@@ -63,5 +70,5 @@ jobs:
       -
         name: Test for GHCR
         run: |
-          docker pull "ghcr.io/lurkars/ghs-server:v0.30.2"
-          docker image inspect "ghcr.io/lurkars/ghs-server:v0.30.2"
+          docker pull ${{ steps.image_lower.outputs.lowercase }}
+          docker image inspect ${{ steps.image_lower.outputs.lowercase }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,9 +1,9 @@
+name: "Publish Docker Image"
+
 on:
   push:
     tags:
       - 'v*'
-
-name: "Publish Docker Image"
 
 env:
   SLUG_DOCKERHUB: ${{ secrets.DOCKER_USERNAME }}/ghs-server
@@ -63,5 +63,5 @@ jobs:
       -
         name: Test for GHCR
         run: |
-          docker pull "ghcr.io/Lurkars/ghs-server:v0.30.2"
+          docker pull "ghcr.io/lurkars/ghs-server:v0.30.2"
           docker image inspect "ghcr.io/lurkars/ghs-server:v0.30.2"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -35,18 +35,16 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
-        id: image_lower
-        uses: ASzc/change-string-case-action@v5
-        with:
-          string: ${{ env.SLUG_TEST }}
-      -
         name: Login to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }} # automatic: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+      -
+        name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
+        run: |
+          echo "SLUG_GHCR_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       -
         name: Build and push
         uses: docker/build-push-action@v3
@@ -68,7 +66,13 @@ jobs:
           docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
       -
+        name: Test Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
+        run: |
+          echo "SLUG_TEST_LC=${TO_CONVERT,,}" >>${GITHUB_ENV}
+        env:
+          TO_CONVERT: '${{ env.SLUG_TEST }}'
+      -
         name: Test for GHCR
         run: |
-          docker pull ${{ steps.image_lower.outputs.lowercase }}
-          docker image inspect ${{ steps.image_lower.outputs.lowercase }}
+          docker pull ${{ SLUG_TEST_LC }}
+          docker image inspect ${{ SLUG_TEST_LC }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -37,7 +37,7 @@ jobs:
       -
         name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
         id: image_lower
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ env.SLUG_TEST }}
       -

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -29,14 +29,12 @@ jobs:
             ${{ env.SLUG_GHCR }}
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -52,7 +50,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Inspect Image published to Docker
-        if: github.event_name != 'pull_request'
         run: |
           docker pull "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
@@ -60,7 +57,6 @@ jobs:
           docker image inspect "gloomhavensecretariat/ghs-server"
       -
         name: Inspect Image published to GHCR
-        if: github.event_name != 'pull_request'
         run: |
           docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -51,14 +51,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       -
-        name: Inspect image
+        name: Inspect Image published to Docker
         if: github.event_name != 'pull_request'
         run: |
           docker pull "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
-          docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
-          docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
           docker pull "gloomhavensecretariat/ghs-server"
           docker image inspect "gloomhavensecretariat/ghs-server"
-          docker pull "ghcr.io/Lurkars/ghs-server:v0.30.2"
+      -
+        name: Inspect Image published to GHCR
+        if: github.event_name != 'pull_request'
+        run: |
+          docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
+          docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
+          docker pull "ghcr.io/lurkars/ghs-server:v0.30.2"
           docker image inspect "ghcr.io/Lurkars/ghs-server:v0.30.2"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
-        -
+      -
         name: Test for GHCR
         run: |
           docker pull "ghcr.io/Lurkars/ghs-server:v0.30.2"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -54,7 +54,11 @@ jobs:
         name: Inspect image
         if: github.event_name != 'pull_request'
         run: |
-          docker pull ${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}
-          docker image inspect ${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}
-          docker pull ${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}
-          docker image inspect ${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}
+          docker pull "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
+          docker image inspect "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
+          docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
+          docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
+          docker pull "gloomhavensecretariat/ghs-server"
+          docker image inspect "gloomhavensecretariat/ghs-server"
+          docker pull "ghcr.io/Lurkars/ghs-server:v0.30.2"
+          docker image inspect "ghcr.io/Lurkars/ghs-server:v0.30.2"

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -74,5 +74,5 @@ jobs:
       -
         name: Test for GHCR
         run: |
-          docker pull ${{ SLUG_TEST_LC }}
-          docker image inspect ${{ SLUG_TEST_LC }}
+          docker pull ${{ env.SLUG_TEST_LC }}
+          docker image inspect ${{ env.SLUG_TEST_LC }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -7,8 +7,7 @@ on:
 
 env:
   SLUG_DOCKERHUB: ${{ secrets.DOCKER_USERNAME }}/ghs-server
-  SLUG_GHCR: ghcr.io/${{ github.repository_owner }}/ghs-server
-  SLUG_TEST: ghcr.io/Lurkars/ghs-server:v0.30.2
+  SLUG_GHCR: ${{ github.repository_owner }}/ghs-server
 
 jobs:
   build-and-publish-docker-image:
@@ -27,7 +26,7 @@ jobs:
         with:
           images: |
             ${{ env.SLUG_DOCKERHUB }}
-            ${{ env.SLUG_GHCR }}
+            ghcr.io/${{ env.SLUG_GHCR }}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2
@@ -42,10 +41,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }} # automatic: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
       -
-        name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
-        run: |
-          echo "SLUG_GHCR_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
-      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -58,21 +53,12 @@ jobs:
         run: |
           docker pull "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
           docker image inspect "${{ env.SLUG_DOCKERHUB }}:${{ steps.meta.outputs.version }}"
-          docker pull "gloomhavensecretariat/ghs-server"
-          docker image inspect "gloomhavensecretariat/ghs-server"
+      -
+        name: Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
+        run: |
+          echo "SLUG_GHCR_LC=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       -
         name: Inspect Image published to GHCR
         run: |
-          docker pull "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
-          docker image inspect "${{ env.SLUG_GHCR }}:${{ steps.meta.outputs.version }}"
-      -
-        name: Test Lowercase GHCR repository name # required because docker doesn't support uppercase chars: https://github.com/docker/build-push-action/issues/37
-        run: |
-          echo "SLUG_TEST_LC=${TO_CONVERT,,}" >>${GITHUB_ENV}
-        env:
-          TO_CONVERT: '${{ env.SLUG_TEST }}'
-      -
-        name: Test for GHCR
-        run: |
-          docker pull ${{ env.SLUG_TEST_LC }}
-          docker image inspect ${{ env.SLUG_TEST_LC }}
+          docker pull "ghcr.io/${{ env.SLUG_GHCR_LC }}:${{ steps.meta.outputs.version }}"
+          docker image inspect "ghcr.io/${{ env.SLUG_GHCR_LC }}:${{ steps.meta.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Execute the `jar`-file with your Java Runtime Environment or run `java -jar ghs-
 
 ### Build and run using Docker
 
+[![Publish Docker Image](https://github.com/Lurkars/ghs-server/actions/workflows/publish-docker-image.yml/badge.svg)](https://github.com/Lurkars/ghs-server/actions/workflows/publish-docker-image.yml)
+
 If you want to use docker for running on port 8080 execute following:
 
 ```shell
-docker build -t ghs-server .
-docker run --rm -p 8080:8080 ghs-server
+docker pull ghcr.io/lurkars/ghs-server
+docker run --rm -p 8080:8080 ghcr.io/lurkars/ghs-server
 ```
 
 For usage with docker compose, simple run `docker compose up -d`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 version: "3.8"
 services:
   ghs-server:
-    build:
-      context: ./
-      dockerfile: Dockerfile
+    container_name: ghs-server
+    image: ghcr.io/Lurkars/ghs-server
+
     ports:
       - "8080:8080"


### PR DESCRIPTION
Primary changes are to lower case the Github username (ie. `Lurkars`) as it causes conflicts with Docker's commands.

I tried a few ways, but settled on a simple bash pattern replacement. Other ways gave deprecation warnings.

My implementation works in this specific use case. A more comprehensive solution would also lower-case the Tag. I assume **version tags never contain an uppercase character** for this project.

Also included a Build Badge and small update to the readme.


**Evidence it should work with the `Lurkars` username**: see steps "Test Lowercase..." and "Test for GHCR" https://github.com/jgwehr/ghs-server/actions/runs/3605474342/jobs/6075908069

**Current working version test**
- https://github.com/jgwehr/ghs-server/actions/runs/3605522885
- https://github.com/jgwehr/ghs-server/pkgs/container/ghs-server/56781565?tag=v-test-11working
- https://hub.docker.com/layers/snoopeppers/ghs-server/v-test-11working/images/sha256-219e8bce8a8c3a7792a7de48411e0d43cb77abfe065d02c2fa482a36bcc73b0a?context=explore

